### PR TITLE
Do not require the type of the element to be part of the OAI identifier

### DIFF
--- a/src/main/java/org/eurocris/openaire/cris/validator/CRISValidator.java
+++ b/src/main/java/org/eurocris/openaire/cris/validator/CRISValidator.java
@@ -523,7 +523,7 @@ public class CRISValidator {
 					final MetadataType metadata = x.getMetadata();
 					if ( metadata != null ) {
 						final Element el = (Element) metadata.getAny();
-						return "oai:" + repoIdentifier.get() + ":" + el.getLocalName() + "s/" + el.getAttribute( "id" );
+						return "oai:" + repoIdentifier.get() + ":" + el.getAttribute( "id" );
 					} else {
 						// make the test trivially satisfied for records with no metadata
 						return x.getHeader().getIdentifier();


### PR DESCRIPTION
Adaptation for https://github.com/openaire/guidelines-cris-managers/issues/85 and https://github.com/openaire/guidelines-cris-managers/pull/90