### PR TITLE
Finish: Adapt identifier validation to match also oai:{service}:{internal ID} rule

### DIFF
--- a/src/main/java/org/eurocris/openaire/cris/validator/CRISValidator.java
+++ b/src/main/java/org/eurocris/openaire/cris/validator/CRISValidator.java
@@ -16,12 +16,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -518,16 +518,17 @@ public class CRISValidator {
 	private CheckingIterable<RecordType> wrapCheckOAIIdentifier( final CheckingIterable<RecordType> checker ) {
 		final Optional<String> repoIdentifier = endpoint.getRepositoryIdentifer();
 		if ( repoIdentifier.isPresent() ) {
-			final Function<RecordType, List<String>> expectedFunction = new Function<RecordType, List<String>>() {
+			final Function<RecordType, Set<String>> expectedFunction = new Function<RecordType, Set<String>>() {
 				
 				@Override
-				public List<String> apply( final RecordType x ) {
+				public Set<String> apply( final RecordType x ) {
 					final MetadataType metadata = x.getMetadata();
-					List<String> results = new ArrayList<String>();
+					final Set<String> results = new HashSet<>();
 					if ( metadata != null ) {
 						final Element el = (Element) metadata.getAny();
-						results.add("oai:" + repoIdentifier.get() + ":" + el.getLocalName() + "s/" + el.getAttribute( "id" ));
-						results.add("oai:" + repoIdentifier.get() + ":" + el.getAttribute( "id" ));
+						final String id = el.getAttribute( "id" );
+						results.add("oai:" + repoIdentifier.get() + ":" + el.getLocalName() + "s/" + id);
+						results.add("oai:" + repoIdentifier.get() + ":" + id);
 					} else {
 						// make the test trivially satisfied for records with no metadata
 					    results.add(x.getHeader().getIdentifier());
@@ -536,7 +537,7 @@ public class CRISValidator {
 				}
 
 			};
-			return checker.checkForOneEqualsOnList( expectedFunction, (( final RecordType record ) -> record.getHeader().getIdentifier() ), "OAI identifier other than expected" );
+			return checker.checkForAllValueInSet( expectedFunction, ( ( final RecordType record ) -> record.getHeader().getIdentifier() ), "OAI identifier other than expected" );
 		} else {
 			return checker;
 		}

--- a/src/main/java/org/eurocris/openaire/cris/validator/util/CheckingIterable.java
+++ b/src/main/java/org/eurocris/openaire/cris/validator/util/CheckingIterable.java
@@ -1,10 +1,10 @@
 package org.eurocris.openaire.cris.validator.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -225,23 +225,27 @@ public abstract class CheckingIterable<T> implements Iterable<T> {
 		}, null );
 	}
 
-    public <U> CheckingIterable<T> checkForOneEqualsOnList(final Function<T, List<U>> expectedFunction, Function<T, U> realFunction, final String message) {
-        return checkForAll(new Predicate<T>()
+	/**
+	 * Build a CheckingIterable which checks that a derived value belongs to a derived set for all elements of the collection.
+	 * @param expectedFunction the function to construct the set of expected values
+	 * @param realFunction the function extract the actual value
+	 * @param message the message to signal when the actual value does not belong to the expected set
+	 * @return this CheckingIterable wrapped to check the condition
+	 */
+    public <U> CheckingIterable<T> checkForAllValueInSet( final Function<T, Set<U>> expectedFunction, final Function<T, U> realFunction, final String message ) {
+        return checkForAll( new Predicate<T>()
         {
 
             @Override
             public boolean test(final T obj)
             {
-                final List<U> expectedValue = expectedFunction.apply(obj);
-                final U realValue = realFunction.apply(obj);
-                
-                if(!expectedValue.contains(realValue)) {
-                    throw new AssertionFailedError( message + "; object: " + obj );
-                }
+                final Set<U> expectedValues = expectedFunction.apply( obj );
+                final U realValue = realFunction.apply( obj );
+                assertTrue( message + "; object: " + obj, expectedValues.contains( realValue ) );
                 return true;
             }
 
-        }, null);
+        }, null );
     }
 	   
 	/**

--- a/src/main/java/org/eurocris/openaire/cris/validator/util/CheckingIterable.java
+++ b/src/main/java/org/eurocris/openaire/cris/validator/util/CheckingIterable.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -224,6 +225,25 @@ public abstract class CheckingIterable<T> implements Iterable<T> {
 		}, null );
 	}
 
+    public <U> CheckingIterable<T> checkForOneEqualsOnList(final Function<T, List<U>> expectedFunction, Function<T, U> realFunction, final String message) {
+        return checkForAll(new Predicate<T>()
+        {
+
+            @Override
+            public boolean test(final T obj)
+            {
+                final List<U> expectedValue = expectedFunction.apply(obj);
+                final U realValue = realFunction.apply(obj);
+                
+                if(!expectedValue.contains(realValue)) {
+                    throw new AssertionFailedError( message + "; object: " + obj );
+                }
+                return true;
+            }
+
+        }, null);
+    }
+	   
 	/**
 	 * Build a CheckingIterable which checks that the values of a function for all elements of the collection are unique.
 	 * @param function the mapping from the collection element to the key that should be unique


### PR DESCRIPTION
Taking #6 a bit further: use a Set<T> instead of a List<T>, a more fitting name for the method in CheckingIterator and a small refactoring.