### PR TITLE
JDK 11 compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,17 @@
 			<artifactId>junit</artifactId>
 			<version>[4.13.1,)</version>
 		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>2.3.1</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
@@ -38,10 +49,11 @@
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>
+
 			<plugin>
 				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb22-plugin</artifactId>
-				<version>0.10.0</version>
+				<artifactId>maven-jaxb2-plugin</artifactId>
+				<version>0.14.0</version>
 				<executions>
 					<execution>
                         <phase>generate-sources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eurocris</groupId>
 	<artifactId>openaire-cris-validator</artifactId>
-	<version>1.0.1-SNAPSHOT</version>
+	<version>1.1.1-SNAPSHOT</version>
 	<name>OpenAIRE CRIS Prototype Validator</name>
 	<description>A basic prototype validator to assess whether an OAI-PMH endpoint complies with the requirements set by the OpenAIRE Guidelines for CRIS Manager 1.1.</description>
 	<organization>
@@ -42,10 +42,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>3.8.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>11</source>
+					<target>11</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<guidelines.project.dir>../guidelines-cris-managers</guidelines.project.dir>
 		<fully.qualified.main.class.name>org.eurocris.openaire.cris.validator.CRISValidator</fully.qualified.main.class.name>
+		<maven.compiler.version>1.8</maven.compiler.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -44,8 +45,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>${maven.compiler.version}</source>
+					<target>${maven.compiler.version}</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,13 @@
 				<groupId>org.jvnet.jaxb2.maven2</groupId>
 				<artifactId>maven-jaxb2-plugin</artifactId>
 				<version>0.14.0</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.glassfish.jaxb</groupId>
+						<artifactId>jaxb-runtime</artifactId>
+						<version>2.3.3</version>
+					</dependency>
+				</dependencies>
 				<executions>
 					<execution>
                         <phase>generate-sources</phase>
@@ -162,8 +169,8 @@
 						</transformationSet>
 					</transformationSets>
 					<catalogs>
-						<catalog>schemas/cached/catalog.xml</catalog>
-						<catalog>schemas/catalog.xml</catalog>
+						<catalog>${guidelines.project.dir}/schemas/cached/catalog.xml</catalog>
+						<catalog>${guidelines.project.dir}/schemas/catalog.xml</catalog>
 					</catalogs>
 				</configuration>
 				<dependencies>


### PR DESCRIPTION
Dear,

this PR makes the validator buildable under JAVA 11, one of the JAVA LTS versions and referees to issue #9 .

Best, Andreas