### PR TITLE
Fix running the validator from command-line (#12)

### DIFF
--- a/src/main/java/org/eurocris/openaire/cris/validator/CRISValidator.java
+++ b/src/main/java/org/eurocris/openaire/cris/validator/CRISValidator.java
@@ -196,7 +196,7 @@ public class CRISValidator {
 	 * @throws IOException on a problem accessing a schema
 	 * @throws ParserConfigurationException when an XML parser cannot be instantiated
 	 */
-	public CRISValidator( final URL endpointBaseUrl ) throws SAXException, IOException, ParserConfigurationException {
+	protected CRISValidator( final URL endpointBaseUrl ) throws SAXException, IOException, ParserConfigurationException {
 		if ( endpoint == null || ! endpointBaseUrl.toExternalForm().equals( endpoint.getBaseUrl() ) ) {
 			endpoint = new OAIPMHEndpoint( endpointBaseUrl, getParserSchema(), CONN_STREAM_FACTORY );		
 			metadataFormatsByPrefix.clear();

--- a/src/test/java/org/eurocris/openaire/cris/validator/metadataTests/CRISValidator.java
+++ b/src/test/java/org/eurocris/openaire/cris/validator/metadataTests/CRISValidator.java
@@ -1,0 +1,27 @@
+package org.eurocris.openaire.cris.validator.metadataTests;
+
+import java.io.IOException;
+import java.net.URL;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.xml.sax.SAXException;
+
+/**
+ * Adapting {@link org.eurocris.openaire.cris.validator.CRISValidator} for usage in this package.
+ * Just inheriting the protected constructor is needed.
+ */
+public class CRISValidator extends org.eurocris.openaire.cris.validator.CRISValidator {
+
+	/**
+	 * A simple call to {@link org.eurocris.openaire.cris.validator.CRISValidator#CRISValidator( URL )}.
+	 * @param endpointBaseUrl
+	 * @throws SAXException
+	 * @throws IOException
+	 * @throws ParserConfigurationException
+	 */
+	protected CRISValidator(URL endpointBaseUrl) throws SAXException, IOException, ParserConfigurationException {
+		super( endpointBaseUrl );
+	}
+
+}

--- a/src/test/java/org/eurocris/openaire/cris/validator/metadataTests/MetadataFormatTest.java
+++ b/src/test/java/org/eurocris/openaire/cris/validator/metadataTests/MetadataFormatTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.fail;
 
 import java.net.URL;
 
-import org.eurocris.openaire.cris.validator.CRISValidator;
 import org.junit.Test;
 
 /**


### PR DESCRIPTION
JUnit can't cope with multiple public constructors on the test class.
We therefore make the one with the `URL` parameter `protected`.