### PR TITLE
Use hostname in serialization

### DIFF
--- a/src/main/java/org/eurocris/openaire/cris/validator/CRISValidator.java
+++ b/src/main/java/org/eurocris/openaire/cris/validator/CRISValidator.java
@@ -776,7 +776,6 @@ public class CRISValidator {
 			fail( "While validating element " + elString + ": " + e );
 		}
 	}
-	
 }
 
 /**
@@ -801,6 +800,7 @@ class FileLoggingConnectionStreamFactory implements OAIPMHEndpoint.ConnectionStr
 	@Override
 	public InputStream makeInputStream( final URLConnection conn ) throws IOException {
 		InputStream inputStream = conn.getInputStream();
+		String baseURLhostname = conn.getURL().getHost();
 		if ( logDir != null ) {
 			final Path logDirPath = Paths.get( logDir );
 			Files.createDirectories( logDirPath );
@@ -816,10 +816,9 @@ class FileLoggingConnectionStreamFactory implements OAIPMHEndpoint.ConnectionStr
  				sb.append( m2.group( 1 ) );
  			}
 			final DateTimeFormatter dtf = DateTimeFormatter.ofPattern( "yyyyMMdd'T'HHmmss.SSS" );
-			final String logFilename = "oai-pmh--" + dtf.format( LocalDateTime.now() ) + "--" + sb.toString() + ".xml";
+			final String logFilename = baseURLhostname + "_oai-pmh--" + dtf.format( LocalDateTime.now() ) + "--" + sb.toString() + ".xml";
 			inputStream = new FileSavingInputStream( inputStream, logDirPath.resolve( logFilename ) );
 		}
 		return inputStream;
 	}
-	
 }


### PR DESCRIPTION
I'm including an improvement by @ACz-UniBi which he made before we leaped to 2.0.0.

Motivation: In order to facilitate the use of the validator to validate multiple endpoints, it is handy to expand the file naming pattern of the copies of the harvested OAI-PMH responses with the name of the host the info comes from.